### PR TITLE
Update esdt-tokens.md

### DIFF
--- a/docs/developers/esdt-tokens.md
+++ b/docs/developers/esdt-tokens.md
@@ -15,11 +15,11 @@ ESDT tokens can be issued, owned and held by any Account on the Elrond network, 
 
 # **Issuance of ESDT tokens**
 
-ESDT tokens are issued via a request to the Metachain, which is a transaction submitted by the Account which will own and manage the tokens. When issuing a token, one must provide a valid token name and a valid ticker. This transaction has the form:
+ESDT tokens are issued via a request to the Metachain, which is a transaction submitted by the Account which will manage the tokens. When issuing a token, one must provide a valid token name and a valid ticker. This transaction has the form:
 
 ```
 IssuanceTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 5000000000000000000 (5 eGLD)
     GasLimit: 50000000
@@ -33,7 +33,7 @@ IssuanceTransaction {
 Optionally, the properties can be set when issuing a contract. Example:
 ```
 IssuanceTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 5000000000000000000 (5 eGLD)
     GasLimit: 50000000
@@ -51,15 +51,15 @@ IssuanceTransaction {
 
 The receiver address `erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u` is a built-in system smart contract (not a VM-executable contract), which only handles token issuance and other token management operations, and does not handle any transfers.
 
-There are two restrictions imposed on the name of the token to be issued:
+Token Name:
 
-- its length must be between 10 and 20 characters
-- all characters must be alphanumeric
+- length between 3 and 20 characters
+- alphanumeric characters only
 
-Also, the ticker has to respect the following:
+Token Ticker:
 
-- its length must be between 3 and 8 chacarters
-- alphanumeric only and letters must be uppercase
+- length between 3 and 10 chacarters
+- alphanumeric UPPERCASE only
 
 The contract will add a random string to the ticker thus creating the token identfier. The random string starts with “-” and has 6 more random characters.
 
@@ -78,10 +78,11 @@ IssuanceTransaction {
 }
 ```
 
-Once this transaction is processed by the Metachain, Alice becomes the designated **owner of AliceTokens**, and is granted a balance of 4091 AliceTokens, to do with them as she pleases. She can increase the total supply of tokens at a later time, if needed. For more operations available to ESDT token owners, see [Token management](/developers/esdt-tokens#token-management).
+Once this transaction is processed by the Metachain, Alice becomes the designated **manager of AliceTokens**, and is granted a balance of 4091 AliceTokens, to do with them as she pleases. She can increase the total supply of tokens at a later time, if needed. For more operations available to ESDT token managers, see [Token management](/developers/esdt-tokens#token-management).
 
-If the issue transaction is successful, a smart contract result will mint the owner with the provided total supply will be generated. In that smart contract result, the `data` field will contain a transfer sintax which is explained below. What is important to note is that the token identifier can be fetched from
-here in order to use it for transfers. Alternatively, the token identifier can be fetched from the API (explaind also below).
+If the issue transaction is successful, a smart contract result will mint the requested token and supply in the account used for issuance, which is also the token manager. 
+
+In that smart contract result, the `data` field will contain a transfer sintax which is explained below. What is important to note is that the token identifier can be fetched from here in order to use it for transfers. Alternatively, the token identifier can be fetched from the API (explaind also below).
 
 # **Transfers**
 
@@ -149,31 +150,31 @@ Sending a transaction containing both an ESDT transfer _and a method call_ allow
 
 # **Token management**
 
-The Account which submitted the issuance request for a custom token automatically becomes the owner of the token (see [Issuance of ESDT tokens](/developers/esdt-tokens#issuance-of-esdt-tokens)). The owner of a token has the ability to manage the properties, the total supply and the availability of a token. Because smart contracts are Accounts as well, a smart contract can also issue and own ESDT tokens and perform management operations by sending the appropriate transactions, as shown below.
+The Account which submitted the issuance request for a custom token automatically becomes the manager of the token (see [Issuance of ESDT tokens](/developers/esdt-tokens#issuance-of-esdt-tokens)). The manager of a token has the ability to manage the properties, the total supply and the availability of a token. Because smart contracts are Accounts as well, a smart contract can also issue and own ESDT tokens and perform management operations by sending the appropriate transactions, as shown below.
 
 ## **Configuration properties of an ESDT token**
 
 Every ESDT token has a set of properties which control what operations are possible with it. See [Management operations](/developers/esdt-tokens#management-operations) below for the operations controlled by them. The properties are:
 
-- `canMint` - more units of this token can be minted by the owner after initial issuance, increasing the supply
+- `canMint` - more units of this token can be minted by the token manager after initial issuance, increasing the supply
 - `canBurn` - users may "burn" some of their tokens, reducing the supply
-- `canPause` - the owner may prevent all transactions of the token, apart from minting and burning
-- `canFreeze` - the owner may freeze a specific account, preventing transfers to and from that account
-- `canWipe` - the owner may wipe out the tokens held by a frozen account, reducing the supply
-- `canChangeOwner` - ownership of the token can be transferred to a different account
-- `canUpgrade` - the owner may change these properties
+- `canPause` - the token manager may prevent all transactions of the token, apart from minting and burning
+- `canFreeze` - the token manager may freeze the token balance in a specific account, preventing transfers to and from that account
+- `canWipe` - the token manager may wipe out the tokens held by a frozen account, reducing the supply
+- `canChangeOwner` - token management can be transferred to a different account
+- `canUpgrade` - the token manager may change these properties
 
 ## **Management operations**
 
-The owner of an ESDT token has a number of operations at their disposal, which control how the token is used by other users. All of these operations require ownership of the token - no other account may perform them. One special exception is the `ESDTBurn` operation, which is available to any Account which holds units of the token in cause.
+The manager of an ESDT token has a number of operations at their disposal, which control how the token is used by other users. These operations can only be performed by the token manager - no other account may perform them. One special exception is the `ESDTBurn` operation, which is available to any Account which holds units of the token in cause.
 
 ### **Minting**
 
-The owner of an ESDT token can increase the total supply by sending to the Metachain a transaction of the following form:
+The manager of an ESDT token can increase the total supply by sending to the Metachain a transaction of the following form:
 
 ```
 MintTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
@@ -183,13 +184,13 @@ MintTransaction {
 }
 ```
 
-Following this transaction, the total supply of tokens is increased by the new supply specified in the Data field, and the owner receives that amount of tokens into their balance.
+Following this transaction, the total supply of tokens is increased by the new supply specified in the Data field, and the manager receives that amount of tokens into their balance.
 
 This operation requires that the option `canMint` is set to `true` for the token.
 
 ### **Burning**
 
-Anyone that holds an amount of ESDT tokens may burn it at their discretion, effectively losing them permanently. This operation reduces the total supply of tokens, and cannot be undone, unless the token owner mints more tokens. Burning is performed by sending a transaction to the Metachain, of the form:
+Anyone that holds an amount of ESDT tokens may burn it at their discretion, effectively losing them permanently. This operation reduces the total supply of tokens, and cannot be undone, unless the token manager mints more tokens. Burning is performed by sending a transaction to the Metachain, of the form:
 
 ```
 BurnTransaction {
@@ -209,11 +210,11 @@ This operation requires that the option `canBurn` is set to `true` for the token
 
 ### **Pausing and Unpausing**
 
-The owner of an ESDT token may choose to suspend all transactions of the token, except minting, freezing/unfreezing and wiping. The transaction form is as follows:
+The manager of an ESDT token may choose to suspend all transactions of the token, except minting, freezing/unfreezing and wiping. The transaction form is as follows:
 
 ```
 PauseTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
@@ -226,7 +227,7 @@ The reverse operation, unpausing, will allow transactions of the token again:
 
 ```
 UnpauseTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
@@ -239,11 +240,11 @@ These two operations require that the option `canPause` is set to `true`.
 
 ### **Freezing and Unfreezing**
 
-The owner of an ESDT token may freeze the tokens held by a specific Account. As a consequence, no tokens may be transferred to or from the frozen Account. Freezing and unfreezing the tokens of an Account are operations designed to help token owners to comply with regulations. The transaction that freezes the tokens of an Account has the form:
+The manager of an ESDT token may freeze the tokens held by a specific Account. As a consequence, no tokens may be transferred to or from the frozen Account. Freezing and unfreezing the tokens of an Account are operations designed to help token managers to comply with regulations. The transaction that freezes the tokens of an Account has the form:
 
 ```
 FreezeTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
@@ -257,7 +258,7 @@ The reverse operation, unfreezing, will allow further transfers to and from the 
 
 ```
 UnfreezeTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
@@ -271,11 +272,11 @@ These two operations require that the option `canFreeze` is set to `true`.
 
 ### **Wiping**
 
-The owner of an ESDT token may wipe out all the tokens held by a frozen Account. This operation is similar to burning the tokens, but the Account must have been frozen beforehand, and it must be done by the token owner. Wiping the tokens of an Account is an operation designed to help token owners to comply with regulations.Such a transaction has the form:
+The manager of an ESDT token may wipe out all the tokens held by a frozen Account. This operation is similar to burning the tokens, but the Account must have been frozen beforehand, and it must be done by the token manager. Wiping the tokens of an Account is an operation designed to help token managers to comply with regulations.Such a transaction has the form:
 
 ```
 WipeTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token managers>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
@@ -287,19 +288,19 @@ WipeTransaction {
 
 This operation requires that the option `canWipe` is set to `true`.
 
-### **Transferring ownership**
+### **Transferring token management rights**
 
-The owner of an ESDT token may transfer the ownership to another Account. This can be done with a transaction of the form:
+The manager of an ESDT token may transfer the management rights to another Account. This can be done with a transaction of the form:
 
 ```
 TransferOwnershipTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
     Data: "transferOwnership" +
           "@" + <token identifier in hexadecimal encoding> +
-          "@" + <account address to transfer ownership to in hexadecimal encoding>
+          "@" + <account address of the new token manager in hexadecimal encoding>
 }
 ```
 
@@ -309,11 +310,11 @@ This operation requires that the option `canChangeOwner` is set to `true`.
 
 ### **Upgrading (changing properties)**
 
-The owner of an ESDT token may individually change any of the properties of the token, or multiple properties at once. Such an operation is performed by a transaction of the form:
+The manager of an ESDT token may individually change any of the properties of the token, or multiple properties at once. Such an operation is performed by a transaction of the form:
 
 ```
 UpgradingTransaction {
-    Sender: <account address of the token owner>
+    Sender: <account address of the token manager>
     Receiver: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
     Value: 0
     GasLimit: 50000000
@@ -327,7 +328,7 @@ UpgradingTransaction {
 }
 ```
 
-As an example, assume that the "AliceTokens" discussed in earlier sections has the property `canWipe` set to `true` and the property `canBurn` set to `false`, but Alice, the token owner, wants to change these property to `false` and `true`, respectively. The transaction that would achieve this change is:
+As an example, assume that the "AliceTokens" discussed in earlier sections has the property `canWipe` set to `true` and the property `canBurn` set to `false`, but Alice, the token manager, wants to change these property to `false` and `true`, respectively. The transaction that would achieve this change is:
 
 ```
 UpgradingTransaction {
@@ -573,7 +574,7 @@ The `returnData` member will contain an array of the properties in a fixed order
   "Q2FuVXBncmFkZS10cnVl",                         | can upgrade               | CanUpgrade-true
   "Q2FuTWludC10cnVl",                             | can mint                  | CanMint-true
   "Q2FuQnVybi10cnVl",                             | can burn                  | CanBurn-true
-  "Q2FuQ2hhbmdlT3duZXItZmFsc2U=",                 | can change owner address  | CanChangeOwner-true
+  "Q2FuQ2hhbmdlT3duZXItZmFsc2U=",                 | can change token management address  | CanChangeOwner-true
   "Q2FuUGF1c2UtdHJ1ZQ==",                         | can pause                 | CanPause-true
   "Q2FuRnJlZXplLXRydWU=",                         | can freeze                | CanFreeze-true
   "Q2FuV2lwZS10cnVl"                              | can wipe                  | CanWipe-true


### PR DESCRIPTION
- Changed name length: 3-20 chars, token ticker 3-8 chars
- replaced "token owner" with "token manager" to avoid confusions about real asset ownership, which is always with the account holding the token.
i.e. I have 100 BUSD tokens, I own them, but Binance is the token manager