### PR TITLE
Replace all occurrences of api.elrond.com with gateway.elrond.com

### DIFF
--- a/docs/developers/constants.md
+++ b/docs/developers/constants.md
@@ -1,0 +1,38 @@
+---
+id: constants
+title: Constants
+---
+
+Elrond uses some constants, which are specific to each chain (mainnet, testnet or devnet). The updated values can be found at these sources:
+
+**Mainnet**:
+- https://gateway.elrond.com/network/config
+- https://github.com/ElrondNetwork/elrond-config-mainnet
+
+**Testnet**:
+- https://testnet-gateway.elrond.com/network/config
+- https://github.com/ElrondNetwork/elrond-config-testnet
+
+**Devnet**:
+- https://devnet-gateway.elrond.com/network/config
+- https://github.com/ElrondNetwork/elrond-config-devnet
+
+At the time of writing, the most used constants values for mainnet were:
+
+- Round duration: 6 seconds
+- Epoch duration: 14400 rounds, 24 hours
+- Min gas price: 1000000000
+- Min gas limit: 50000
+- Chain ID: `1` (`T` for Testnet, `D` for Devnet)
+- Min deposit for the creation of a system delegation smart contract: 1250 EGLD
+- Min deposit for a validator: 2500 EGLD
+- Number of eligible validators per shard: 400 validators
+- Number of eligible validators per metachain: 400 validators
+- Max number of active (eligible + waiting) validators: 3200 validators
+- Consensus group size on shard: 63 validators
+- Consensus group size on metachain: 400 validators
+- Min deposit for staking provider: 1 EGLD
+- Min deposit for legacy delegation: 10 EGLD
+- Unbonding duration for legacy delegation: 144000 blocks
+- Unbonding duration for staking providers: 10 epochs
+- EGLD denomination: 18

--- a/docs/developers/esdt-tokens.md
+++ b/docs/developers/esdt-tokens.md
@@ -441,7 +441,7 @@ There are a number of API endpoints that one can use to interact with ESDT data.
 Returns an array of ESDT Tokens that the specified address has interacted with (issued, sent or received).
 
 ```
-https://api.elrond.com/address/*bech32Address*/esdt
+https://gateway.elrond.com/address/*bech32Address*/esdt
 ```
 
 | Param         | Required                                  | Type     | Description                           |
@@ -471,7 +471,7 @@ https://api.elrond.com/address/*bech32Address*/esdt
 Returns the balance of an address for specific ESDT Tokens.
 
 ```
-https://api.elrond.com/address/*bech32Address*/esdt/*tokenIdentifier*
+https://gateway.elrond.com/address/*bech32Address*/esdt/*tokenIdentifier*
 ```
 
 | Param           | Required                                  | Type     | Description                           |
@@ -506,7 +506,7 @@ For example:
 <!--Request-->
 
 ```
-https://api.elrond.com/network/esdts
+https://gateway.elrond.com/network/esdts
 ```
 
 <!--Response-->
@@ -536,7 +536,7 @@ For example:
 <!--Request-->
 
 ```
-https://api.elrond.com/vm-values/query
+https://gateway.elrond.com/vm-values/query
 ```
 
 ```json
@@ -637,7 +637,7 @@ For example:
 
 <!--Request-->
 ```
-https://api.elrond.com/vm-values/query
+https://gateway.elrond.com/vm-values/query
 ```
 
 ```json

--- a/docs/developers/nft-tokens.md
+++ b/docs/developers/nft-tokens.md
@@ -506,7 +506,7 @@ There are a number of API endpoints that one can use to interact with ESDT NFT d
 Returns the balance of an address for specific ESDT Tokens.
 
 ```
-https://api.elrond.com/address/<bech32Address>/nft/<tokenIdentifier>/nonce/<creation-nonce>
+https://gateway.elrond.com/address/<bech32Address>/nft/<tokenIdentifier>/nonce/<creation-nonce>
 ```
 
 | Param           | Required                                  | Type     | Description                           |
@@ -548,7 +548,7 @@ https://api.elrond.com/address/<bech32Address>/nft/<tokenIdentifier>/nonce/<crea
 Returns the identifiers of the tokens that have been registered by the provided address. 
 
 ```
-https://api.elrond.com/address/<bech32Address>/registered-nfts
+https://gateway.elrond.com/address/<bech32Address>/registered-nfts
 ```
 
 | Param           | Required                                  | Type     | Description                           |
@@ -577,7 +577,7 @@ https://api.elrond.com/address/<bech32Address>/registered-nfts
 Returns the identifiers of the tokens where the given address has the given role.
 
 ```
-https://api.elrond.com/address/<bech32Address>/esdts-with-role/<role>
+https://gateway.elrond.com/address/<bech32Address>/esdts-with-role/<role>
 ```
 
 | Param           | Required                                  | Type     | Description                           |

--- a/docs/developers/signing-transactions/signing-programmatically.md
+++ b/docs/developers/signing-transactions/signing-programmatically.md
@@ -66,6 +66,6 @@ Above, `payload` can be submitted to Elrond API in order to broadcast the transa
 ```
 from erdpy.proxy import ElrondProxy
 
-proxy = ElrondProxy("http://gateway.elrond.com")
+proxy = ElrondProxy("https://gateway.elrond.com")
 tx.send(proxy)
 ```

--- a/docs/developers/signing-transactions/signing-programmatically.md
+++ b/docs/developers/signing-transactions/signing-programmatically.md
@@ -66,6 +66,6 @@ Above, `payload` can be submitted to Elrond API in order to broadcast the transa
 ```
 from erdpy.proxy import ElrondProxy
 
-proxy = ElrondProxy("http://api.elrond.com")
+proxy = ElrondProxy("http://gateway.elrond.com")
 tx.send(proxy)
 ```

--- a/docs/developers/tutorials/counter.md
+++ b/docs/developers/tutorials/counter.md
@@ -40,7 +40,7 @@ In order to deploy the contract on the Testnet you need to have an account with 
 The deploy command is as follows:
 
 ```
-erdpy --verbose contract deploy --project=mycounter --pem="alice.pem" --gas-limit=5000000 --proxy="https://testnet-api.elrond.com" --outfile="counter.json" --recall-nonce --send
+erdpy --verbose contract deploy --project=mycounter --pem="alice.pem" --gas-limit=5000000 --proxy="https://testnet-gateway.elrond.com" --outfile="counter.json" --recall-nonce --send
 ```
 
 Above, `mycounter` refers to the same folder that contains the source code and the build artifacts. The `deploy` command knows to search for the WASM bytecode within this folder.
@@ -82,7 +82,7 @@ export CONTRACT_ADDRESS=$(python3 -c "import json; data = json.load(open('counte
 Now that we have the contract address saved in an shell variable, we can call the `increment` function of the contract as follows:
 
 ```
-erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="increment" --proxy="https://testnet-api.elrond.com" --recall-nonce --send
+erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="increment" --proxy="https://testnet-gateway.elrond.com" --recall-nonce --send
 ```
 
 Execute the command above a few times, with some pause in between. Then feel free to experiment with calling the `decrement` function.
@@ -90,7 +90,7 @@ Execute the command above a few times, with some pause in between. Then feel fre
 Then, in order to query the value of the counter - that is, to execute the `get` pure function of the contract - run the following:
 
 ```
-erdpy contract query $CONTRACT_ADDRESS --function="get" --proxy="https://testnet-api.elrond.com"
+erdpy contract query $CONTRACT_ADDRESS --function="get" --proxy="https://testnet-gateway.elrond.com"
 ```
 
 The output should look like this:
@@ -107,17 +107,17 @@ The previous steps can be summed up in a simple script as follows:
 #!/bin/bash
 
 # Deployment
-erdpy --verbose contract deploy --project=mycounter --pem="alice.pem" --gas-limit=5000000 --proxy="https://testnet-api.elrond.com" --outfile="counter.json" --recall-nonce --send
+erdpy --verbose contract deploy --project=mycounter --pem="alice.pem" --gas-limit=5000000 --proxy="https://testnet-gateway.elrond.com" --outfile="counter.json" --recall-nonce --send
 export CONTRACT_ADDRESS=$(python3 -c "import json; data = json.load(open('address.json')); print(data['contract'])")
 
 # Interaction
-erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="increment" --proxy="https://testnet-api.elrond.com" --recall-nonce --send
+erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="increment" --proxy="https://testnet-gateway.elrond.com" --recall-nonce --send
 sleep 10
-erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="increment" --proxy="https://testnet-api.elrond.com" --recall-nonce --send
+erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="increment" --proxy="https://testnet-gateway.elrond.com" --recall-nonce --send
 sleep 10
-erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="decrement" --proxy="https://testnet-api.elrond.com" --recall-nonce --send
+erdpy --verbose contract call $CONTRACT_ADDRESS --pem="alice.pem" --gas-limit=2000000 --function="decrement" --proxy="https://testnet-gateway.elrond.com" --recall-nonce --send
 sleep 10
 
 # Querying
-erdpy contract query $CONTRACT_ADDRESS --function="get" --proxy="https://testnet-api.elrond.com"
+erdpy contract query $CONTRACT_ADDRESS --function="get" --proxy="https://testnet-gateway.elrond.com"
 ```

--- a/docs/sdk-and-tools/erdpy/configuring-erdpy.md
+++ b/docs/sdk-and-tools/erdpy/configuring-erdpy.md
@@ -9,7 +9,7 @@ In order to view the current configuration, one can issue the command `erdpy con
 
 ```
 {
-    "proxy": "https://api.elrond.com",
+    "proxy": "https://gateway.elrond.com",
     "txVersion": "1",
     "dependencies.llvm.tag": "v...",
     "dependencies.arwentools.tag": "v...",
@@ -22,7 +22,7 @@ One can alter the current configuration using the command `erdpy config set`. Fo
 
 ```
 $ erdpy config set chainID 1...
-$ erdpy config set proxy https://api.elrond.com
+$ erdpy config set proxy https://gateway.elrond.com
 ```
 
 :::tip

--- a/docs/sdk-and-tools/erdpy/sending-bulk-transactions.md
+++ b/docs/sdk-and-tools/erdpy/sending-bulk-transactions.md
@@ -75,7 +75,7 @@ declare -a TRANSACTIONS=(
 
 # DO NOT MODIFY ANYTHING FROM HERE ON
 
-PROXY="https://api.elrond.com"
+PROXY="https://gateway.elrond.com"
 DENOMINATION="000000000000000000"
 
 # We recall the nonce of the wallet

--- a/docs/sdk-and-tools/proxy.md
+++ b/docs/sdk-and-tools/proxy.md
@@ -27,7 +27,7 @@ In the figure above:
 
 ## **Official Elrond Proxy**
 
-The official instance of the Elrond Proxy is located at [https://api.elrond.com](https://api.elrond.com/).
+The official instance of the Elrond Proxy is located at [https://gateway.elrond.com](https://gateway.elrond.com/).
 
 ## **Setup a Proxy Instance**
 

--- a/docs/sdk-and-tools/rest-api/addresses.md
+++ b/docs/sdk-and-tools/rest-api/addresses.md
@@ -7,7 +7,7 @@ Get information about an Elrond Address.
 
 ## <span class="badge badge-primary">GET</span> **Get Address**
 
-`https://api.elrond.com/address/:bech32Address`
+`https://gateway.elrond.com/address/:bech32Address`
 
 This endpoint allows one to retrieve basic information about an Address (Account).
 
@@ -41,7 +41,7 @@ Address information successfully retrieved.
 
 ## <span class="badge badge-primary">GET</span> **Get Address Nonce**
 
-https://api.elrond.com**/address/:bech32Address/nonce**
+https://gateway.elrond.com**/address/:bech32Address/nonce**
 
 This endpoint allows one to retrieve the nonce of an Address.
 
@@ -71,7 +71,7 @@ Nonce successfully retrieved.
 
 ## <span class="badge badge-primary">GET</span> **Get Address Balance**
 
-https://api.elrond.com**/address/:bech32Address/balance**
+https://gateway.elrond.com**/address/:bech32Address/balance**
 
 This endpoint allows one to retrieve the balance of an Address.
 
@@ -101,7 +101,7 @@ Balance successfully retrieved.
 
 ## <span class="badge badge-primary">GET</span> **Get Address Transactions**
 
-https://api.elrond.com**/address/:bech32Address/transactions**
+https://gateway.elrond.com**/address/:bech32Address/transactions**
 
 This endpoint allows one to retrieve the latest 20 Transactions sent from an Address.
 
@@ -181,7 +181,7 @@ This endpoint requires the presence of an Elastic Search instance (populated thr
 
 ## <span class="badge badge-primary">GET</span> **Get Storage Value for Address**
 
-https://api.elrond.com**/address/:bech32Address/key/:key**
+https://gateway.elrond.com**/address/:bech32Address/key/:key**
 
 This endpoint allows one to retrieve a value stored within the Blockchain for a given Address.
 
@@ -214,7 +214,7 @@ Value (hex-encoded) successfully retrieved.
 
 ## <span class="badge badge-primary">GET</span> **Get all storage for Address**
 
-https://api.elrond.com**/address/:bech32Address/keys**
+https://gateway.elrond.com**/address/:bech32Address/keys**
 
 This endpoint allows one to retrieve all the key-value pairs stored under a given account.
 

--- a/docs/sdk-and-tools/rest-api/blocks.md
+++ b/docs/sdk-and-tools/rest-api/blocks.md
@@ -7,7 +7,7 @@ Query blocks information.
 
 ## <span class="badge badge-primary">GET</span> **Get Hyperblock by Nonce**
 
-`https://api.elrond.com//hyperblock/by-nonce/:nonce`
+`https://gateway.elrond.com//hyperblock/by-nonce/:nonce`
 
 This endpoint allows one to query a Hyperblock by its nonce.
 
@@ -86,7 +86,7 @@ A **hyperblock** is composed using a **metablock** as a starting point - therefo
 
 ## <span class="badge badge-primary">GET</span> **Get Hyperblock by Hash**
 
-`https://api.elrond.com/hyperblock/by-hash/:hash`
+`https://gateway.elrond.com/hyperblock/by-hash/:hash`
 
 This endpoint allows one to query a Hyperblock by its hash.
 

--- a/docs/sdk-and-tools/rest-api/blocks.md
+++ b/docs/sdk-and-tools/rest-api/blocks.md
@@ -157,7 +157,7 @@ This endpoint is only is only defined by the Proxy. The Observer does not expose
 
 ## <span class="badge badge-primary">GET</span> **Get Block by Nonce**
 
-`http://localhost:8080/block/:shard/by-nonce/:nonce`
+`https://gateway.elrond.com/block/:shard/by-nonce/:nonce`
 
 This endpoint allows one to query a Shard Block by its nonce (or height).
 
@@ -229,7 +229,7 @@ For Observers, the `shard` parameter should not be set.
 
 ## <span class="badge badge-primary">GET</span> **Get Block by Hash**
 
-`http://localhost:8080/block/:shard/by-hash/:hash`
+`https://gateway.elrond.com/block/:shard/by-hash/:hash`
 
 This endpoint allows one to query a Shard Block by its hash.
 

--- a/docs/sdk-and-tools/rest-api/blocks.md
+++ b/docs/sdk-and-tools/rest-api/blocks.md
@@ -7,7 +7,7 @@ Query blocks information.
 
 ## <span class="badge badge-primary">GET</span> **Get Hyperblock by Nonce**
 
-`https://gateway.elrond.com//hyperblock/by-nonce/:nonce`
+`https://gateway.elrond.com/hyperblock/by-nonce/:nonce`
 
 This endpoint allows one to query a Hyperblock by its nonce.
 

--- a/docs/sdk-and-tools/rest-api/network.md
+++ b/docs/sdk-and-tools/rest-api/network.md
@@ -7,7 +7,7 @@ Query information about the Network.
 
 ## <span class="badge badge-primary">GET</span> **Get Network Configuration**
 
-`https://api.elrond.com/network/config`
+`https://gateway.elrond.com/network/config`
 
 This endpoint allows one to query basic details about the configuration of the Network.
 
@@ -46,7 +46,7 @@ Configuration details retrieved successfully.
 
 ## <span class="badge badge-primary">GET</span> **Get Shard Status**
 
-`https://api.elrond.com/network/status/:shardId`
+`https://gateway.elrond.com/network/status/:shardId`
 
 This endpoint allows one to query the status of a given Shard.
 

--- a/docs/sdk-and-tools/rest-api/nodes.md
+++ b/docs/sdk-and-tools/rest-api/nodes.md
@@ -7,7 +7,7 @@ Query Nodes (Peers) information.
 
 ## <span class="badge badge-primary">GET</span> **Get Heartbeat Status**
 
-`https://api.elrond.com/node/heartbeatstatus`
+`https://gateway.elrond.com/node/heartbeatstatus`
 
 This endpoint allows one to query the status of the Nodes.
 

--- a/docs/sdk-and-tools/rest-api/transactions.md
+++ b/docs/sdk-and-tools/rest-api/transactions.md
@@ -7,7 +7,7 @@ Send Transactions to the Blockchain and query information about them.
 
 ## <span class="badge badge-success">POST</span> Send Transaction
 
-`https://api.elrond.com/transaction/send`
+`https://gateway.elrond.com/transaction/send`
 
 This endpoint allows one to send a signed Transaction to the Blockchain.
 
@@ -61,7 +61,7 @@ For Nodes (Observers or Validators with the HTTP API enabled), this endpoint **o
 Here's an example of a request:
 
 ```
-POST https://api.elrond.com/transaction/send HTTP/1.1
+POST https://gateway.elrond.com/transaction/send HTTP/1.1
 Content-Type: application/json
 
 {
@@ -80,7 +80,7 @@ Content-Type: application/json
 
 ## <span class="badge badge-success">POST</span> Send Multiple Transactions
 
-`https://api.elrond.com/transaction/send-multiple`
+`https://gateway.elrond.com/transaction/send-multiple`
 
 This endpoint allows one to send a bulk of Transactions to the Blockchain.
 
@@ -128,7 +128,7 @@ For Nodes (Observers or Validators with the HTTP API enabled), this endpoint **o
 Here's an example of a request:
 
 ```
-POST https://api.elrond.com/transaction/send-multiple HTTP/1.1
+POST https://gateway.elrond.com/transaction/send-multiple HTTP/1.1
 Content-Type: application/json
 
 [
@@ -163,7 +163,7 @@ Content-Type: application/json
 
 **Nodes and observers**
 
-`https://api.elrond.com/transaction/simulate`
+`https://gateway.elrond.com/transaction/simulate`
 
 This endpoint allows one to send a signed Transaction to the Blockchain in order to simulate its execution.
 This can be useful in order to check if the transaction will be successfully executed before actually sending it.
@@ -265,7 +265,7 @@ Example response for cross-shard transactions:
 
 ## <span class="badge badge-success">POST</span> Estimate Cost of Transaction
 
-`https://api.elrond.com/transaction/cost`
+`https://gateway.elrond.com/transaction/cost`
 
 This endpoint allows one to estimate the cost of a transaction.
 
@@ -305,7 +305,7 @@ This endpoint returns the cost on the transaction in **gas units**. The returned
 Here's an example of a request:
 
 ```
-POST https://api.elrond.com/transaction/cost HTTP/1.1
+POST https://gateway.elrond.com/transaction/cost HTTP/1.1
 Content-Type: application/json
 
 {
@@ -320,7 +320,7 @@ Content-Type: application/json
 
 ## <span class="badge badge-primary">GET</span> **Get Transaction**
 
-`https://api.elrond.com/transaction/:txHash`
+`https://gateway.elrond.com/transaction/:txHash`
 
 This endpoint allows one to query the details of a Transaction.
 
@@ -378,7 +378,7 @@ The optional query parameter **`sender`** is only applicable to requests against
 
 ## <span class="badge badge-primary">GET</span> **Get Transaction Status**
 
-`https://api.elrond.com/transaction/:txHash/status`
+`https://gateway.elrond.com/transaction/:txHash/status`
 
 This endpoint allows one to query the Status of a Transaction.
 

--- a/docs/sdk-and-tools/rest-api/versions-and-changelog.md
+++ b/docs/sdk-and-tools/rest-api/versions-and-changelog.md
@@ -19,7 +19,7 @@ This is the API launched at the Genesis.
 
 This API version brought new features such as the [_hyperblock_-related endpoints](/sdk-and-tools/rest-api/blocks#get-hyperblock-by-nonce), useful for monitoring the blockchain. Furthermore, the `GET transaction` endpoint has been adjusted to include extra fields - for example, the so-called _hyperblock coordinates_ (the _nonce_ and the _hash_ of the containing hyperblock).
 
-This API **has never been deployed to the central instance** of the Elrond Proxy, available at [api.elrond.com](https://api.elrond.com/). However, until November 2020, **this API has been deployed on-premises** to several partners and 3rd party services (such as Exchange systems) - in the shape of [Observing Squads](/integrators/observing-squad), set up via the Mainnet installation scripts - version [e1.0.0](https://github.com/ElrondNetwork/elrond-go-scripts-mainnet/releases/tag/e1.0.0).
+This API **has never been deployed to the central instance** of the Elrond Proxy, available at [gateway.elrond.com](https://gateway.elrond.com/). However, until November 2020, **this API has been deployed on-premises** to several partners and 3rd party services (such as Exchange systems) - in the shape of [Observing Squads](/integrators/observing-squad), set up via the Mainnet installation scripts - version [e1.0.0](https://github.com/ElrondNetwork/elrond-go-scripts-mainnet/releases/tag/e1.0.0).
 
 This version of the API requires Observer Nodes with tag [e1.1.0](https://github.com/ElrondNetwork/elrond-go/releases/tag/e1.1.0) or greater.
 

--- a/docs/sdk-and-tools/rest-api/virtual-machine.md
+++ b/docs/sdk-and-tools/rest-api/virtual-machine.md
@@ -7,7 +7,7 @@ Query values stored within Smart Contracts.
 
 ## <span class="badge badge-success">POST</span> Compute Output of Pure Function
 
-`https://api.elrond.com/vm-values/query`
+`https://gateway.elrond.com/vm-values/query`
 
 This endpoint allows one to execute - with no side-effects - a pure function of a Smart Contract and retrieve the execution results (the Virtual Machine Output).
 
@@ -67,7 +67,7 @@ The VM Output is retrieved successfully.
 Here's an example of a request:
 
 ```
-POST https://api.elrond.com/vm-values/query HTTP/1.1
+POST https://gateway.elrond.com/vm-values/query HTTP/1.1
 Content-Type: application/json
 
 {
@@ -81,7 +81,7 @@ Content-Type: application/json
 
 ## <span class="badge badge-success">POST</span> Compute Hex Output of Pure Function
 
-`https://api.elrond.com/vm-values/hex`
+`https://gateway.elrond.com/vm-values/hex`
 
 This endpoint allows one to execute - with no side-effects - a pure function of a Smart Contract and retrieve the first output value as a hex-encoded string.
 
@@ -115,7 +115,7 @@ The output value is retrieved successfully.
 
 ## <span class="badge badge-success">POST</span> Compute String Output of Pure Function
 
-`https://api.elrond.com/vm-values/string`
+`https://gateway.elrond.com/vm-values/string`
 
 This endpoint allows one to execute - with no side-effects - a pure function of a Smart Contract and retrieve the first output value as a string.
 
@@ -149,7 +149,7 @@ The output value is retrieved successfully.
 
 ## <span class="badge badge-success">POST</span> Get Integer Output of Pure Function
 
-`https://api.elrond.com/vm-values/int`
+`https://gateway.elrond.com/vm-values/int`
 
 This endpoint allows one to execute - with no side-effects - a pure function of a Smart Contract and retrieve the first output value as an integer.
 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -171,7 +171,7 @@ For example:
 
 Path Parameters
 
-`https://api.elrond.com/transaction/*param*`
+`https://gateway.elrond.com/transaction/*param*`
 
 | Param         | Required                                  | Type     | Description                           |
 | ------------- | ----------------------------------------- | -------- | ------------------------------------- |

--- a/docs/validators/staking/staking.md
+++ b/docs/validators/staking/staking.md
@@ -74,7 +74,7 @@ The following commands assume that the PEM file for your Wallet was saved with t
 The command to submit a staking transaction with `erdpy` is this:
 
 ```
-erdpy --verbose validator stake --pem=walletKey.pem --value="<stake-value>" --validators-file=<validators-json-file> --proxy=https://api.elrond.com --estimate-gas --recall-nonce
+erdpy --verbose validator stake --pem=walletKey.pem --value="<stake-value>" --validators-file=<validators-json-file> --proxy=https://gateway.elrond.com --estimate-gas --recall-nonce
 ```
 
 Notice that we are using the `walletKey.pem` file. Moreover, before executing this command, you need to replace the following:
@@ -105,7 +105,7 @@ Notice also that there is no calculation for "Gas Limit". If you provide the `--
 Here's an example for a staking command for one node:
 
 ```
-erdpy --verbose validator stake --pem=walletKey.pem --value="2500000000000000000000" --validators-file=my-validators.json --proxy=https://api.elrond.com --estimate-gas --recall-nonce
+erdpy --verbose validator stake --pem=walletKey.pem --value="2500000000000000000000" --validators-file=my-validators.json --proxy=https://gateway.elrond.com --estimate-gas --recall-nonce
 ```
 
 :::note important
@@ -115,7 +115,7 @@ You must take **denomination** into account when specifying the `value` paramete
 For two nodes, it becomes this:
 
 ```
-erdpy --verbose validator stake --pem=walletKey.pem --value="5000000000000000000000" --validators-file=my-validators.json --proxy=https://api.elrond.com --estimate-gas --recall-nonce
+erdpy --verbose validator stake --pem=walletKey.pem --value="5000000000000000000000" --validators-file=my-validators.json --proxy=https://gateway.elrond.com --estimate-gas --recall-nonce
 ```
 
 # **The --reward-address parameter**
@@ -127,7 +127,7 @@ Alternatively, you can tell `erdpy` to specify another wallet to which your rewa
 For example, a staking command for a single node, with a reward address specified, looks like this:
 
 ```
-erdpy --verbose validator stake --pem=walletKey.pem --reward-address="erd1sg4u62lzvgkeu4grnlwn7h2s92rqf8a64z48pl9c7us37ajv9u8qj9w8xg" --value="2500000000000000000000" --number-of-nodes=1  --nodes-public-keys="b617d8bc442bda59510f77e04a1680e8b2d3293c8c4083d94260db96a4d732deaaf9855fa0cef2273f5a67b4f442c725efc06a5d366b9f15a66da9eb8208a09c9ab4066b6b3d38c3cf1ea7fab6489a90713b3b56d87de68c6558c80d7533bf27" --proxy=https://api.elrond.com --estimate-gas --recall-nonce
+erdpy --verbose validator stake --pem=walletKey.pem --reward-address="erd1sg4u62lzvgkeu4grnlwn7h2s92rqf8a64z48pl9c7us37ajv9u8qj9w8xg" --value="2500000000000000000000" --number-of-nodes=1  --nodes-public-keys="b617d8bc442bda59510f77e04a1680e8b2d3293c8c4083d94260db96a4d732deaaf9855fa0cef2273f5a67b4f442c725efc06a5d366b9f15a66da9eb8208a09c9ab4066b6b3d38c3cf1ea7fab6489a90713b3b56d87de68c6558c80d7533bf27" --proxy=https://gateway.elrond.com --estimate-gas --recall-nonce
 ```
 
 The above command will submit a staking command and will also inform the Staking SmartContract that the rewards should be transferred to the wallet `erd1sg4u62lzvgkeu4grnlwn7h2s92rqf8a64z48pl9c7us37ajv9u8qj9w8xg` .

--- a/docs/validators/staking/unjailing.md
+++ b/docs/validators/staking/unjailing.md
@@ -117,7 +117,7 @@ The following commands assume that the PEM file for your Wallet was saved with t
 The command to submit an unjailing transaction with `erdpy` is this:
 
 ```
-erdpy --verbose validator unjail --pem=walletKey.pem --value="<unjail-value>" --nodes-public-keys="<BLS1>,<BLS2>,...,<BLS99>" --proxy=https://api.elrond.com --estimate-gas --recall-nonce
+erdpy --verbose validator unjail --pem=walletKey.pem --value="<unjail-value>" --nodes-public-keys="<BLS1>,<BLS2>,...,<BLS99>" --proxy=https://gateway.elrond.com --estimate-gas --recall-nonce
 ```
 
 Notice that we are using the `walletKey.pem` file. Moreover, before executing this command, you need to replace the following:
@@ -130,7 +130,7 @@ Notice also that there is no calculation for "Gas Limit". If you provide the `--
 Here's an example for an unjailing command for one validator:
 
 ```
-erdpy --verbose validator unjail --pem=walletKey.pem --value="2500000000000000000000" --nodes-public-keys="b617d8bc442bda59510f77e04a1680e8b2d3293c8c4083d94260db96a4d732deaaf9855fa0cef2273f5a67b4f442c725efc06a5d366b9f15a66da9eb8208a09c9ab4066b6b3d38c3cf1ea7fab6489a90713b3b56d87de68c6558c80d7533bf27" --proxy=https://api.elrond.com --estimate-gas --recall-nonce
+erdpy --verbose validator unjail --pem=walletKey.pem --value="2500000000000000000000" --nodes-public-keys="b617d8bc442bda59510f77e04a1680e8b2d3293c8c4083d94260db96a4d732deaaf9855fa0cef2273f5a67b4f442c725efc06a5d366b9f15a66da9eb8208a09c9ab4066b6b3d38c3cf1ea7fab6489a90713b3b56d87de68c6558c80d7533bf27" --proxy=https://gateway.elrond.com --estimate-gas --recall-nonce
 ```
 
 :::note important
@@ -140,7 +140,7 @@ You must take **denomination** into account when specifying the `value` paramete
 For two validators, the command becomes this one:
 
 ```
-erdpy --verbose validator unjail --pem=walletKey.pem --value="5000000000000000000000" --nodes-public-keys="b617d8bc442bda59510f77e04a1680e8b2d3293c8c4083d94260db96a4d732deaaf9855fa0cef2273f5a67b4f442c725efc06a5d366b9f15a66da9eb8208a09c9ab4066b6b3d38c3cf1ea7fab6489a90713b3b56d87de68c6558c80d7533bf27,f921a0f76ed70e8a806c6f9119f87b12700f96f732e6070b675e0aec10cb0723803202a4c40194847c38195db07b1001f6d50c81a82b949e438cd6dd945c2eb99b32c79465aefb9144c8668af67e2d01f71b81842d9b94e4543a12616cb5897d" --proxy=https://api.elrond.com --estimate-gas --recall-nonce
+erdpy --verbose validator unjail --pem=walletKey.pem --value="5000000000000000000000" --nodes-public-keys="b617d8bc442bda59510f77e04a1680e8b2d3293c8c4083d94260db96a4d732deaaf9855fa0cef2273f5a67b4f442c725efc06a5d366b9f15a66da9eb8208a09c9ab4066b6b3d38c3cf1ea7fab6489a90713b3b56d87de68c6558c80d7533bf27,f921a0f76ed70e8a806c6f9119f87b12700f96f732e6070b675e0aec10cb0723803202a4c40194847c38195db07b1001f6d50c81a82b949e438cd6dd945c2eb99b32c79465aefb9144c8668af67e2d01f71b81842d9b94e4543a12616cb5897d" --proxy=https://gateway.elrond.com --estimate-gas --recall-nonce
 ```
 
 Notice that the two BLS public keys are separated by a comma, with no extra space between them.


### PR DESCRIPTION
#### Description of the pull request (what is new / what has changed)
If I understood correctly third party devs should use gateway.elrond.com as api.elrond.com is for internal use and has a different interface. Therefore I did replace api.elrond.com with gateway.elrond.com everywhere.

#### Did you test the changes locally ?
- [x] yes
- [ ] no

#### Which category(categories) does this pull request belong to?
- [ ] document new feature
- [ ] update documentation that is not relevant anymore
- [ ] add examples or more information about a component
- [ ] fix grammar issues
- [x] other
