### PR TITLE
Update erdpy version to 3.8

### DIFF
--- a/docs/sdk-and-tools/erdpy/installing-erdpy.md
+++ b/docs/sdk-and-tools/erdpy/installing-erdpy.md
@@ -11,8 +11,7 @@ How to install erdpy
 
 Before installing **erdpy**, please make sure you have a working **Python 3** environment:
 
-- **3.6** or later on Linux
-- **3.8** or later on MacOS
+- **3.8** or later on Linux and MacOS
 
 Smart contracts written in C require the ncurses library routines for compiling. Install them using the following:
 

--- a/docs/sdk-and-tools/erdpy/installing-erdpy.md
+++ b/docs/sdk-and-tools/erdpy/installing-erdpy.md
@@ -25,7 +25,7 @@ In order to install **erdpy** using the `erdpy-up` installation script, run the 
 
 ```
 wget -O erdpy-up.py https://raw.githubusercontent.com/ElrondNetwork/elrond-sdk-erdpy/master/erdpy-up.py
-python3 erdpy-up.py
+python3.8 erdpy-up.py
 ```
 
 This will create a light Python virtual environment (based on `venv`) in `~/elrondsdk/erdpy-venv `and also include `~/elrondsdk`in your **`$PATH`** variable (by editing the appropriate `.profile` file).


### PR DESCRIPTION
<!-- For external contributors: Make sure that you are on a new branch that started from `external` branch. -->

#### Description of the pull request (what is new / what has changed)

Because erdpy has a new dependency on ledgercomm, the required version of python has changed on linux from 3.6 to 3.8
Also, on ubuntu 18.04 LTS, even after installing python 3.8, the `python3 --version` still comes up as `Python 3.6.9`. As such, it's necessary to run `python3.8 erdpy-up.py` instead of `python3 erdpyup.py`

#### Did you test the changes locally ?
- [x] yes
- [ ] no

#### Which category(categories) does this pull request belong to?
- [ ] document new feature
- [x] update documentation that is not relevant anymore
- [ ] add examples or more information about a component
- [ ] fix grammar issues
- [ ] other
