### PR TITLE
Add command to build the smart contract

### DIFF
--- a/docs/developers/tutorials/your-first-dapp.md
+++ b/docs/developers/tutorials/your-first-dapp.md
@@ -130,7 +130,16 @@ cd contract/ping-pong
 We now have the source code for the smart contract, but we need to compile it into a *binary* that Elrond Virtual Machine (**Arwen**) can run. Arwen can run Web Assembly code, so we need to compile our Rust source code into Web Assembly (WASM).
 
 Run the following command in order to build the rust smart contract into a *wasm file*.
+
+```
+erdpy contract build
+```
+
+The last output from the command should be:
+
+```
 INFO:projects.core:WASM file generated: output/ping-pong.wasm
+```
 
 After running this command line, we see that a wasm file was generated. This file contains the runtime code for our smart contract.
 


### PR DESCRIPTION
<!-- For external contributors: Make sure that you are on a new branch that started from `external` branch. -->

#### Description of the pull request (what is new / what has changed)

Added missing command to build the smart contract into the tutorial for new dapp.

Sorry for not starting from `external` branch, but this branch doesn't contain that page.

#### Did you test the changes locally ?
- [x] yes
- [ ] no

#### Which category(categories) does this pull request belong to?
- [ ] document new feature
- [ ] update documentation that is not relevant anymore
- [ ] add examples or more information about a component
- [ ] fix grammar issues
- [x] other
