### PR TITLE
add openAPI JSON export link

### DIFF
--- a/docs/sdk-and-tools/rest-api/api-elrond-com.md
+++ b/docs/sdk-and-tools/rest-api/api-elrond-com.md
@@ -12,4 +12,5 @@ References for `api.elrond.com`:
 
 - Github repository: [https://github.com/ElrondNetwork/api.elrond.com](https://github.com/ElrondNetwork/api.elrond.com)
 - Swagger docs: [https://api.elrond.com](https://api.elrond.com)
+- Raw JSON Swagger OpenAPI definitions: [https://api.elrond.com/-json](https://api.elrond.com/-json)
 - Elrond blog: [https://elrond.com/blog/elrond-api-internet-scale-defi](https://elrond.com/blog/elrond-api-internet-scale-defi)


### PR DESCRIPTION
```<!-- For external contributors: Make sure that you are on a new branch that started from the `external` branch. -->``` sorry, this document is not present on the external branch.

#### Description of the pull request (what is new / what has changed)

The OpenAPI contract for `api.elrond.com` is not published anywhere on GitHub. Instead, it can be obtained only by exporting it from https://api.elrond.com/-json. This was not obvious to find, only by going through the history of the telegram dev channel. (Where other users had same difficulties: https://t.me/ElrondDevelopers/45333) 

#### Did you test the changes locally ?
- [ ] yes
- [x] no -> trivial, one line change

#### Which category (categories) does this pull request belong to?
- [ ] document new feature
- [ ] update documentation that is not relevant anymore
- [x] add examples or more information about a component
- [ ] fix grammar issues
- [ ] other
