### PR TITLE
Fixed extra @ at ChangeOwnerAddress

### DIFF
--- a/docs/developers/built-in-functions.md
+++ b/docs/developers/built-in-functions.md
@@ -54,7 +54,7 @@ ChangeOwnerAddressTransaction {
     Receiver: <SC address>
     Value: 0
     GasLimit: 6_000_000
-    Data: "ChangeOwnerAddress@" +
+    Data: "ChangeOwnerAddress" +
           "@" + <new owner address in hexadecimal encoding>
 }
 ```


### PR DESCRIPTION
<!-- For external contributors: Make sure that you are on a new branch that started from the `external` branch. (Did not start from the external branch as that is outdated and does not even have the built-in functions file -->

#### Description of the pull request (what is new / what has changed)
The ChangeOwnerAddress Smart Contract built-in function had an extra '@' between the name of the function and the argument. Fixed that.

#### Did you test the changes locally ?
- [X] yes
- [ ] no

#### Which category (categories) does this pull request belong to?
- [ ] document new feature
- [ ] update documentation that is not relevant anymore
- [ ] add examples or more information about a component
- [ ] fix grammar issues
- [X] other
