### PR TITLE
Sc build reference fix (was missing in overview)

### DIFF
--- a/docs/developers/overview.md
+++ b/docs/developers/overview.md
@@ -65,6 +65,7 @@ Learn about transaction's gas and how a fee is calculated
 | [Rust testing framework](/developers/developer-reference/rust-testing-framework)                                         | Test your Smart Contract directly in Rust.                                                      |
 | [Rust testing framework functions reference](/developers/developer-reference/rust-testing-framework-functions-reference) | A list of available functions to be used when testing your Smart Contract in Rust.              |
 | [Rust smart contract debugging](/developers/developer-reference/rust-smart-contract-debugging)                           | How to debug your Smart Contract.                                                               |
+| [Rust smart contract build reference](/developers/developer-reference/smart-contract-build-reference)                    | How to build and organize your Smart Contract.                                                  |
 | [Random numbers in smart contracts](/developers/developer-reference/random-numbers-in-smart-contracts)                   | How to generate random number in Smart Contracts.                                               |
 
 ### Smart Contract Developers Best Practices


### PR DESCRIPTION
<!-- For external contributors: Make sure that you are on a new branch that started from the `external` branch. -->

#### Description of the pull request (what is new / what has changed)


#### Did you test the changes locally ?
- [x] yes
- [ ] no

#### Which category (categories) does this pull request belong to?
- [ ] document new feature
- [ ] update documentation that is not relevant anymore
- [ ] add examples or more information about a component
- [ ] fix grammar issues
- [x] other - new page was missing from overview
