### PR TITLE
In cookbooks, adjust the sections about relayed transactions

### DIFF
--- a/docs/sdk-and-tools/sdk-js/sdk-js-cookbook-v14.md
+++ b/docs/sdk-and-tools/sdk-js/sdk-js-cookbook-v14.md
@@ -2364,18 +2364,16 @@ After the `10-epoch unbonding period` is complete, we can proceed with withdrawi
 ```
 
 ### Relayed transactions
-We are currently on the `third iteration (V3)` of relayed transactions. V1 and V2 will soon be deactivated, so we will focus on V3.
+We are currently on the third iteration (V3) of relayed transactions. V1 and V2 will be deactivated soon, so we'll focus on V3.
 
-For V3, two new fields have been added to transactions:
-- relayer
-- relayerSignature
+For V3, two new fields have been added on transactions: `relayer` and `relayerSignature`.
 
-Signing Process:
-1. The relayer must be set before the sender signs the transaction.
-2. Once the sender has signed, the relayer can also sign the transaction and broadcast it.
+Note that:
+1. the sender and the relayer can sign the transaction in any order.
+2. before any of the sender or relayer can sign the transaction, the `relayer` field must be set.
+3. relayed transactions require an additional `50,000` of gas.
+4. the sender and the relayer must be in the same network shard.
 
-**Important Consideration**:
-Relayed V3 transactions require an additional `50,000` gas.
 Let’s see how to create a relayed transaction:
 
 ```js

--- a/docs/sdk-and-tools/sdk-js/sdk-js-cookbook-v15.md
+++ b/docs/sdk-and-tools/sdk-js/sdk-js-cookbook-v15.md
@@ -2384,18 +2384,16 @@ After the `10-epoch unbonding period` is complete, we can proceed with withdrawi
 ```
 
 ### Relayed transactions
-We are currently on the `third iteration (V3)` of relayed transactions. V1 and V2 will soon be deactivated, so we will focus on V3.
+We are currently on the third iteration (V3) of relayed transactions. V1 and V2 will be deactivated soon, so we'll focus on V3.
 
-For V3, two new fields have been added to transactions:
-- relayer
-- relayerSignature
+For V3, two new fields have been added on transactions: `relayer` and `relayerSignature`.
 
-Signing Process:
-1. The relayer must be set before the sender signs the transaction.
-2. Once the sender has signed, the relayer can also sign the transaction and broadcast it.
+Note that:
+1. the sender and the relayer can sign the transaction in any order.
+2. before any of the sender or relayer can sign the transaction, the `relayer` field must be set.
+3. relayed transactions require an additional `50,000` of gas.
+4. the sender and the relayer must be in the same network shard.
 
-**Important Consideration**:
-Relayed V3 transactions require an additional `50,000` gas.
 Let’s see how to create a relayed transaction:
 
 ```js

--- a/docs/sdk-and-tools/sdk-py.md
+++ b/docs/sdk-and-tools/sdk-py.md
@@ -2762,7 +2762,17 @@ tx_hash = entrypoint.send_transaction(transaction)
 
 ### Relayed transactions
 
-We are currently on the third iteration of relayed transactions. V1 and V2 are soon to be deactivated so we'll focus on V3. For V3, two new fields have been added on transactions: `relayer` and `relayerSignature`. Before the sender signs the transaction, the relayer needs to be set. After the sender has signed the transaction, the relayer can also sign the transaction and broadcast it. Keep in mind that, for relayed V3 transactions we need an extra `50_000` gas. Let's see how we can create a relayed transaction:
+We are currently on the third iteration (V3) of relayed transactions. V1 and V2 will be deactivated soon, so we'll focus on V3.
+
+For V3, two new fields have been added on transactions: `relayer` and `relayerSignature`.
+
+Note that:
+1. the sender and the relayer can sign the transaction in any order.
+2. before any of the sender or relayer can sign the transaction, the `relayer` field must be set.
+3. relayed transactions require an additional `50,000` of gas.
+4. the sender and the relayer must be in the same network shard.
+
+Let’s see how to create a relayed transaction:
 
 ```py
 from pathlib import Path


### PR DESCRIPTION
#### Description of the pull request (what is new / what has changed)

In the first place, we've adjusted the previous phrasing:

> once the sender has signed, the relayer can also sign the transaction

... which was a bit too strict, since the sender and the relayer can sign in any order.

Additionally, did some adjustments so that the sections about relayed transactions are now identical, on all cookbooks.

#### Did you test the changes locally ?
- [x] yes
- [ ] no

#### Which category (categories) does this pull request belong to?
- [ ] document new feature
- [ ] update documentation that is not relevant anymore
- [ ] add examples or more information about a component
- [ ] fix grammar issues
- [x] other
